### PR TITLE
Add option for CSS masking

### DIFF
--- a/panel/features/masking.js
+++ b/panel/features/masking.js
@@ -1,11 +1,13 @@
 import {propertyNameOption} from '../feature-helpers.js';
 
 export default propertyNameOption({
-  name: 'Clipping paths',
+  name: 'Masking',
   group: 'Visual Rendering',
-  help: 'Disable region clipping via `clip-path`',
+  help: 'Disable masking via `mask` and `mask-image`',
   propertyNames: [
-    'clip-path',
-    '-webkit-clip-path'
+    'mask',
+    'mask-image',
+    '-webkit-mask',
+    '-webkit-mask-image',
   ]
 });

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -6,6 +6,7 @@ import transforms from './features/transforms.js';
 import supports from './features/supports.js';
 import compositing from './features/compositing.js';
 import clipPath from './features/clip-path.js';
+import masking from './features/masking.js';
 import shape from './features/shape.js';
 import objectFit from './features/object-fit.js';
 
@@ -18,6 +19,7 @@ let features = [
   transforms,
   compositing,
   clipPath,
+  masking,
   shape,
   supports,
   objectFit


### PR DESCRIPTION
Fixes #1 

- Adds option to disable `mask` and `mask-image` CSS properties
- Moves Clipping paths to Visual Rendering group

This can be tested on the sample files located at:
https://github.com/oslego/css-masking-test-files