### PR TITLE
Iframe support

### DIFF
--- a/panel/content-functions.js
+++ b/panel/content-functions.js
@@ -1,0 +1,38 @@
+/**
+ * Retrives the cssText of each <style> element using either the textContent
+ * property or, in the case of JS injected style rules, by walking the CSSOM
+ * and retreiving the `cssText` property of each style rule.
+ */
+export const getStyleElementCssText = () => {
+  return Array.from(document.querySelectorAll('style')).map(style => {
+    if (style.textContent) {
+      return style.textContent;
+    }
+    return Array.from(style.sheet.cssRules).map(rule => rule.cssText).join('');
+  });
+};
+
+
+/**
+ * Sets the textContent of every <style> using the passed CSS text
+ *
+ * @param {string} styles
+ */
+export const setStyleElementCssText = styles => {
+  document.querySelectorAll('style').forEach(style => {
+    let newStyles = styles.shift();
+    if (newStyles !== style.textContent) {
+      style.textContent = newStyles;
+    }
+  });
+};
+
+
+/**
+ * Checks to see if the current document has finished loading
+ *
+ * @returns {boolean} true is the readyState is 'complete', otherwise false
+ */
+export const isDocumentComplete = () => {
+  return document.readyState === 'complete';
+};

--- a/panel/feature-list.js
+++ b/panel/feature-list.js
@@ -1,0 +1,32 @@
+import grid from './features/grid.js';
+import flexbox from './features/flexbox.js';
+import boxSizing from './features/box-sizing.js';
+import sticky from './features/sticky.js';
+import transforms from './features/transforms.js';
+import supports from './features/supports.js';
+import compositing from './features/compositing.js';
+import clipPath from './features/clip-path.js';
+import masking from './features/masking.js';
+import shape from './features/shape.js';
+import objectFit from './features/object-fit.js';
+import customProperties from './features/custom-properties.js';
+import calc from './features/calc.js';
+import transitions from './features/transitions.js';
+
+
+export default [
+  grid,
+  flexbox,
+  boxSizing,
+  sticky,
+  transforms,
+  compositing,
+  clipPath,
+  masking,
+  shape,
+  supports,
+  objectFit,
+  customProperties,
+  calc,
+  transitions
+];

--- a/panel/features/transitions.js
+++ b/panel/features/transitions.js
@@ -6,6 +6,10 @@ export default propertyNameOption({
   help: 'Disable support for transitions',
   propertyNames: [
     '-webkit-transition',
-    'transition'
+    'transition',
+    '-webkit-transition-duration',
+    'transition-duration',
+    '-webkit-transition-delay',
+    'transition-delay'
   ]
 });

--- a/panel/panel.css
+++ b/panel/panel.css
@@ -29,7 +29,9 @@ body {
   background: #000;
   color: #ccc;
 }
-
+.theme--dark .option__checkbox {
+  filter: invert(80%);
+}
 
 
 .option {

--- a/panel/resource-helpers.js
+++ b/panel/resource-helpers.js
@@ -1,0 +1,110 @@
+import {
+  getStyleElementCssText,
+  setStyleElementCssText,
+  isDocumentComplete
+} from './content-functions.js';
+
+
+/**
+ * Returns a list of resources for the inspected window.
+ * 
+ * @returns {Promise} A promise that resolves with an array resources.
+ */
+const getResourcesByType = resourceType => {
+  return new Promise(resolve => {
+    chrome.devtools.inspectedWindow.getResources(resources => {
+      resolve(resources.filter(resource => resource.type === resourceType));
+    });
+  });
+};
+
+
+/**
+ * Returns a list of stylesheet resources for the inspected window.
+ * 
+ * @returns {Promise} A promise that resolves with an array of stylesheet
+ * resources.
+ */
+export const getStylesheets = () => getResourcesByType('stylesheet');
+
+
+/**
+ * Returns a list of document resources for the inspected window.
+ * 
+ * @returns {Promise} A promise that resolves with an array of document
+ * resources.
+ */
+export const getDocuments = () => getResourcesByType('document');
+
+
+/**
+ * Evalulates a expression in a document.
+ * 
+ * @param {string|function} expression - Expression or function to evaluate
+ * @param {Resource} resource - Document to evaluate the expression in
+ * @returns {Promise} A promise that resolves with the expression result
+ */
+export const evalInDocument = (expression, resource) => {
+  let options = {
+    frameURL: resource.url
+  };
+
+  if (typeof expression === 'function') {
+    expression = `(${expression})()`;
+  }
+
+  return new Promise(resolve => {
+    chrome.devtools.inspectedWindow.eval(expression, options, (res, err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+};
+
+
+/**
+ * Waits for a document resource to complete loading.
+ * 
+ * @param {Resource} resource - The document to wait for
+ * @returns {Promise} A promise that resolves once the document is complete
+ */
+export const documentReady = resource => {
+  return new Promise(resolve => {
+    const checkReadyState = async () => {
+      let res = await evalInDocument(isDocumentComplete, resource);
+      if (!res) {
+        setTimeout(checkReadyState, 100);
+      } else {
+        resolve();
+      }
+    };
+    checkReadyState();
+  });
+};
+
+
+/**
+ * Extracts the CSS text for each <style> element of a document resource.
+ * 
+ * @param {Resource} resource - Document to extract the styles from
+ * @returns {Promise} A promise that resolves with an array of cssText
+ */
+export const getStyleElementStyles = async resource => {
+  await documentReady(resource);
+  return evalInDocument(getStyleElementCssText, resource);
+};
+
+
+/**
+ * Updates the CSS text for each <style> element of a document resource.
+ * 
+ * @param {Resource} resource - Document to extract the styles from
+ * @param {string[]} styles - CSS text to apply
+ * @returns {Promise} A promise that resolves with an array of cssText
+ */
+export const setStyleElementStyles = (resource, styles) => {
+  return evalInDocument(`(${setStyleElementCssText})([\`${styles.join('\`,\`')}\`])`, resource);
+};


### PR DESCRIPTION
This PR addresses #5. As part of fixing iframe support panel.js has been broken into separate modules to make things easier to read. Many of the functions have also been converted to use Promises rather than callbacks.

In addition to iframe support, this PR also contains a bug fix for CSS transitions and a minor style update for the UI