### PR TITLE
Add support for multi-column layout

### DIFF
--- a/panel/feature-list.js
+++ b/panel/feature-list.js
@@ -12,6 +12,7 @@ import objectFit from './features/object-fit.js';
 import customProperties from './features/custom-properties.js';
 import calc from './features/calc.js';
 import transitions from './features/transitions.js';
+import columns from './features/columns.js';
 
 
 export default [
@@ -28,5 +29,6 @@ export default [
   objectFit,
   customProperties,
   calc,
-  transitions
+  transitions,
+  columns
 ];

--- a/panel/features/columns.js
+++ b/panel/features/columns.js
@@ -1,0 +1,12 @@
+import {propertyNameOption} from '../feature-helpers.js';
+
+export default propertyNameOption({
+  name: 'Multi-column layout',
+  group: 'Box Layout',
+  help: 'Disable support for columns',
+  propertyNames: [
+    'columns',
+    'column-count',
+    'column-width'
+  ]
+});


### PR DESCRIPTION
This PR adds support for multi-column layout. It adds a new "Box layout" option which — when checked — disables the following properties:

* `columns` (short-hand syntax)
* `column-count`
* `column-width`

### Screenshot
![screen shot 2019-01-23 at 20 23 30](https://user-images.githubusercontent.com/588665/51634784-09457300-1f4d-11e9-96e3-bcd9671ded7a.png)

### Testing
This feature can be tested on the [MDN CSS Multi-column Layout page
](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Columns).