### PR TITLE
Add support for toggling CSS animations

### DIFF
--- a/panel/feature-list.js
+++ b/panel/feature-list.js
@@ -13,7 +13,7 @@ import customProperties from './features/custom-properties.js';
 import calc from './features/calc.js';
 import transitions from './features/transitions.js';
 import columns from './features/columns.js';
-
+import animations from './features/animations.js';
 
 export default [
   grid,
@@ -30,5 +30,6 @@ export default [
   customProperties,
   calc,
   transitions,
+  animations,
   columns
 ];

--- a/panel/features/animations.js
+++ b/panel/features/animations.js
@@ -1,0 +1,13 @@
+import {propertyNameOption} from '../feature-helpers.js';
+
+export default propertyNameOption({
+  name: 'Animations',
+  group: 'Visual Rendering',
+  help: 'Disable support for animations',
+  propertyNames: [
+    '-webkit-animation',
+    'animation',
+    '-webkit-animation-name',
+    'animation-name'
+  ]
+});


### PR DESCRIPTION
This PR adds a toggle for CSS animations. It adds a new "Visual rendering" option which — when checked — disables the following properties:

* `-webkit-animation`
*  `animation`
*  `-webkit-animation-name`
*  `animation-name`

### Screenshot
![screen shot 2019-01-23 at 23 32 24](https://user-images.githubusercontent.com/588665/51644228-5e8e7e00-1f67-11e9-87cd-5b7c95c8c519.png)


### Testing
This feature can be tested on the [MDN Using CSS animations page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations).