### PR TITLE
Add support for custom fonts (@font-face)

### DIFF
--- a/panel/feature-list.js
+++ b/panel/feature-list.js
@@ -14,6 +14,7 @@ import calc from './features/calc.js';
 import transitions from './features/transitions.js';
 import columns from './features/columns.js';
 import animations from './features/animations.js';
+import fonts from './features/fonts.js';
 
 export default [
   grid,
@@ -31,5 +32,6 @@ export default [
   calc,
   transitions,
   animations,
-  columns
+  columns,
+  fonts
 ];

--- a/panel/features/fonts.js
+++ b/panel/features/fonts.js
@@ -3,6 +3,6 @@ import {atRuleIdentifierOption} from '../feature-helpers.js';
 export default atRuleIdentifierOption({
   name: 'Custom fonts',
   group: 'Other',
-  help: 'Disable support for custom fonts defined with `@font-face`',
+  help: 'Disable loading of custom fonts with `@font-face`',
   identifier: 'font-face'
 });

--- a/panel/features/fonts.js
+++ b/panel/features/fonts.js
@@ -1,0 +1,8 @@
+import {atRuleIdentifierOption} from '../feature-helpers.js';
+
+export default atRuleIdentifierOption({
+  name: 'Custom fonts',
+  group: 'Other',
+  help: 'Disable support for custom fonts defined with `@font-face`',
+  identifier: 'font-face'
+});


### PR DESCRIPTION
This PR introduces a toggle for custom fonts. It adds a new option to the "Other" group which, when checked, disables all `@font-face` blocks referenced in stylesheets used by the current document or any iframes. 

_Note: this PR won't disable fonts loaded through the Font Loading API_

### Screenshot
![screen shot 2019-01-30 at 23 25 45](https://user-images.githubusercontent.com/588665/52019682-7d9c8b00-24e6-11e9-9ed0-496f362e88d3.png)