### PR TITLE
Missing prefixes

### DIFF
--- a/extension/panel/features/calc.js
+++ b/extension/panel/features/calc.js
@@ -5,6 +5,7 @@ export default functionNameOption({
   group: 'Other',
   help: 'Disable support for the `calc()` function',
   functionNames: [
-    'calc'
+    'calc',
+    '-webkit-calc'
   ]
 });

--- a/extension/panel/features/columns.js
+++ b/extension/panel/features/columns.js
@@ -7,6 +7,9 @@ export default propertyNameOption({
   propertyNames: [
     'columns',
     'column-count',
-    'column-width'
+    'column-width',
+    '-webkit-columns',
+    '-webkit-column-count',
+    '-webkit-column-width'
   ]
 });

--- a/extension/panel/features/flexbox.js
+++ b/extension/panel/features/flexbox.js
@@ -7,6 +7,8 @@ export default propertyValueOption({
   propertyName: 'display',
   propertyValues: [
     'flex',
-    'inline-flex'
+    'inline-flex',
+    '-webkit-flex',
+    '-webkit-inline-flex'
   ]
 });

--- a/extension/panel/features/flexbox.js
+++ b/extension/panel/features/flexbox.js
@@ -9,6 +9,8 @@ export default propertyValueOption({
     'flex',
     'inline-flex',
     '-webkit-flex',
-    '-webkit-inline-flex'
+    '-webkit-inline-flex',
+    '-webkit-box',
+    '-webkit-inline-box'
   ]
 });

--- a/tests/browser/features/flexbox.js
+++ b/tests/browser/features/flexbox.js
@@ -1,3 +1,9 @@
+/**
+ * Test the `flex` value for the `display` property. This test creates a greem
+ * pseudo-element and applies flex to ensure it fills the parent element space. 
+ * If the browser doesn't support `flex`, the red coloured parent element will
+ * show.
+ */
 addTest({
   name: 'flex',
   group: 'Flexbox',
@@ -11,6 +17,10 @@ addTest({
     }`
 });
 
+/**
+ * Test the `inline-flex` value for the `display` property. The test works in
+ * the same way as the `flex` test above.
+ */
 addTest({
   name: 'inline-flex',
   group: 'Flexbox',
@@ -24,6 +34,9 @@ addTest({
     }`
 });
 
+/**
+ * test for `-webkit-flex` prefix
+ */
 addTest({
   name: '-webkit-flex',
   group: 'Flexbox',
@@ -37,6 +50,9 @@ addTest({
     }`
 });
 
+/**
+ * test for `-webkit-inline-flex` prefix
+ */
 addTest({
   name: '-webkit-inline-flex',
   group: 'Flexbox',
@@ -47,5 +63,36 @@ addTest({
       content: '';
       flex: 1;
       background: <supported-color>
+    }`
+});
+
+/**
+ * test for old `box` formats
+ */
+addTest({
+  name: '-webkit-box',
+  group: 'Flexbox',
+  css: `<indicator-selector> {
+      display: -webkit-box;
+    }
+    <indicator-selector>::before {
+      content: '';
+      display: block;
+      -webkit-box-flex: 1;
+      background: <supported-color>;
+    }`
+});
+
+addTest({
+  name: '-webkit-inline-box',
+  group: 'Flexbox',
+  css: `<indicator-selector> {
+      display: -webkit-inline-box;
+    }
+    <indicator-selector>::before {
+      content: '';
+      display: block;
+      -webkit-box-flex: 1;
+      background: <supported-color>;
     }`
 });


### PR DESCRIPTION
This PR adds missing `-webkit-` prefixes to the following properties:

* `calc`
* `columns`, `column-count` and `column-width`
* `flex`, `inline-flex` and `box` / `inline-box` (the older syntax)

This should close #16 